### PR TITLE
Add test:debug and specify +1 browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Set up browsers as `+1` on most stable browsers I could find.
 
-## 0.0.1 - UNRELEASED
+## 1.0.1 - 2016-04-11
+### Fixed
+- Fixed the `main` setting in package.json
+
+## 1.0.0 - 2016-04-11
 ### Changed
 - Initial version extracted from postscribe
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.2 - 2016-04-11
+### Changed
+- Set up browsers as `+1` on most stable browsers I could find.
+
 ## 0.0.1 - UNRELEASED
 ### Changed
-- Intial version extracted from postscribe
+- Initial version extracted from postscribe
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -112,10 +112,10 @@ gulp.task('serve', ['clean', 'build'], done => {
   });
 });
 
-function karma(configName, failOnError = true) {
-  return done => new Karma({
+function karma(configName, failOnError = true, karmaOptions = {}) {
+  return done => new Karma(Object.assign({
     configFile: path.resolve(`./${configName}.config.babel.js`)
-  }, err => {
+  }, karmaOptions), err => {
     if (err) {
       gutil.log('[test]', 'Tests failed');
       if (failOnError) {
@@ -129,6 +129,8 @@ function karma(configName, failOnError = true) {
 gulp.task('test', karma('karma'));
 
 gulp.task('test:cross-browser', karma('karma-sauce'));
+
+gulp.task('test:debug', karma('karma', true, {singleRun: false}));
 
 gulp.task('test:tdd', karma('karma', false));
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "tdd": "gulp tdd",
     "test": "gulp test",
     "test:cross-browser": "gulp test:cross-browser",
+    "test:debug": "gulp test:debug",
     "watch": "gulp watch"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prescribe",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Tiny, forgiving HTML parser",
   "homepage": "https://github.com/krux/prescribe/",
   "bugs": "https://github.com/krux/prescribe/issues",

--- a/saucelabs.config.babel.js
+++ b/saucelabs.config.babel.js
@@ -34,7 +34,7 @@ export default {
   win10_ie_11: {
     base: 'SauceLabs',
     browserName: 'internet explorer',
-    platform: 'Windows 8',
+    platform: 'Windows 8.1',
     version: '11.0'
   },
   win8_ie_10: {

--- a/saucelabs.config.babel.js
+++ b/saucelabs.config.babel.js
@@ -2,160 +2,79 @@
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 
 export default {
+  win10_chrome_latest: {
+    base: 'SauceLabs',
+    browserName: 'chrome',
+    platform: 'Windows 10',
+    version: ''
+  },
+  win10_chrome_latest_1: {
+    base: 'SauceLabs',
+    browserName: 'chrome',
+    platform: 'Windows 10',
+    version: '47'
+  },
+  win10_firefox_latest: {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    platform: 'Windows 10',
+    version: ''
+  },
+  win10_firefox_latest_1: {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    platform: 'Windows 10',
+    version: '43'
+  },
+  win10_edge_latest: {
+    base: 'SauceLabs',
+    browserName: 'MicrosoftEdge',
+    version: ''
+  },
   win10_ie_11: {
     base: 'SauceLabs',
-    platform: 'Windows 10',
     browserName: 'internet explorer',
+    platform: 'Windows 8',
     version: '11.0'
-  },
-  win10_chrome_48: {
-    base: 'SauceLabs',
-    platform: 'Windows 10',
-    browserName: 'chrome',
-    version: '48.0'
-  },
-  win10_chrome_38: {
-    base: 'SauceLabs',
-    platform: 'Windows 10',
-    browserName: 'chrome',
-    version: '38.0'
-  },
-  win10_chrome_26: {
-    base: 'SauceLabs',
-    platform: 'Windows 10',
-    browserName: 'chrome',
-    version: '26.0'
-  },
-  win10_firefox_44: {
-    base: 'SauceLabs',
-    platform: 'Windows 10',
-    browserName: 'firefox',
-    version: '44.0'
-  },
-  win10_firefox_39: {
-    base: 'SauceLabs',
-    platform: 'Windows 10',
-    browserName: 'firefox',
-    version: '39.0'
-  },
-  win10_edge: {
-    base: 'SauceLabs',
-    platform: 'Windows 10',
-    browserName: 'MicrosoftEdge',
-    version: '20.10240'
   },
   win8_ie_10: {
     base: 'SauceLabs',
-    platform: 'Windows 8',
     browserName: 'internet explorer',
+    platform: 'Windows 8',
     version: '10.0'
-  },
-  win8_chrome_48: {
-    base: 'SauceLabs',
-    platform: 'Windows 8',
-    browserName: 'chrome',
-    version: '48.0'
-  },
-  win8_firefox_44: {
-    base: 'SauceLabs',
-    platform: 'Windows 8',
-    browserName: 'firefox',
-    version: '44.0'
-  },
-  win7_ie_8: {
-    base: 'SauceLabs',
-    platform: 'Windows 7',
-    browserName: 'internet explorer',
-    version: '8.0'
   },
   win7_ie_9: {
     base: 'SauceLabs',
-    platform: 'Windows 7',
     browserName: 'internet explorer',
+    platform: 'Windows 7',
     version: '9.0'
   },
-  win7_ie_10: {
+  win7_ie_8: {
     base: 'SauceLabs',
-    platform: 'Windows 7',
     browserName: 'internet explorer',
-    version: '10.0'
-  },
-  win7_ie_11: {
-    base: 'SauceLabs',
     platform: 'Windows 7',
-    browserName: 'internet explorer',
-    version: '11.0'
+    version: '8.0'
   },
-  win7_chrome_48: {
+  win7_opera_latest: {
     base: 'SauceLabs',
-    platform: 'Windows 7',
-    browserName: 'chrome',
-    version: '48.0'
-  },
-  win7_firefox_44: {
-    base: 'SauceLabs',
-    platform: 'Windows 7',
-    browserName: 'firefox',
-    version: '44.0'
-  },
-  win7_opera_12: {
-    base: 'SauceLabs',
-    platform: 'Windows 7',
     browserName: 'opera',
-    version: '12.12'
-  },
-  win7_safari_5: {
-    base: 'SauceLabs',
     platform: 'Windows 7',
+    version: ''
+  },
+  win7_opera_latest_1: {
+    base: 'SauceLabs',
+    browserName: 'opera',
+    platform: 'Windows 7',
+    version: '11'
+  },
+  el_capitan_safari_latest: {
+    base: 'SauceLabs',
     browserName: 'safari',
-    version: '5.1'
+    version: ''
   },
-  el_capitan_chrome_48: {
+  el_capitan_safari_latest_1: {
     base: 'SauceLabs',
-    platform: 'OS X 10.11',
-    browserName: 'chrome',
-    version: '48.0'
-  },
-  el_capitan_chrome_38: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.11',
-    browserName: 'chrome',
-    version: '38.0'
-  },
-  el_capitan_firefox_44: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.11',
-    browserName: 'firefox',
-    version: '44.0'
-  },
-  el_capitan_firefox_39: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.11',
-    browserName: 'firefox',
-    version: '39.0'
-  },
-  el_capitan_safari_9: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.11',
     browserName: 'safari',
-    version: '9.0'
-  },
-  mountain_lion_chrome_48: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.8',
-    browserName: 'chrome',
-    version: '48.0'
-  },
-  mountain_lion_firefox_44: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.8',
-    browserName: 'firefox',
-    version: '44.0'
-  },
-  mountain_lion_safari_6: {
-    base: 'SauceLabs',
-    platform: 'OS X 10.8',
-    browserName: 'safari',
-    version: '6.0'
+    version: '8'
   }
 };


### PR DESCRIPTION
Sauce allows an empty string to mean latest version of this browser. I've specified the latest and the current previous version here in an impl of the `+1` method for testing (along w/ IE8+). I set windows for most as that seemed to be the most stable OS on Sauce.

I tried the `latest-1` method specified on sauce's site, but it consistently failed.