### PR TITLE
fix(version): fix version in header no longer correct after semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "clean": "gulp clean",
     "doc": "gulp doc",
     "lint": "gulp lint",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "semantic-release": "semantic-release pre && gulp build && npm publish && semantic-release post",
     "start": "gulp serve",
     "tdd": "gulp tdd",
     "tdd:coverage": "gulp tdd:coverage",


### PR DESCRIPTION
Need to run build after semantic-release pre in order to get the right version number

Fixes #27