### PR TITLE
feat(parser): adds `peekToken` to parser

### DIFF
--- a/src/HtmlParser.js
+++ b/src/HtmlParser.js
@@ -47,8 +47,8 @@ export default class HtmlParser {
     }
 
     if (fix) {
-      this._fixedReadToken = fixedReadTokenFactory(this, fixedTokenOptions,
-        () => this._readTokenImpl());
+      this._fixedReadToken = fixedReadTokenFactory(this, fixedTokenOptions, () => this._readTokenImpl());
+      this._fixedPeekToken = fixedReadTokenFactory(this, fixedTokenOptions, () => this._peekTokenImpl());
     }
   }
 
@@ -74,22 +74,36 @@ export default class HtmlParser {
    * The implementation of the token reading.
    *
    * @private
-   * @returns {Token}
+   * @returns {?Token}
    */
   _readTokenImpl() {
-    // Enumerate detects in order
+    const token = this._peekTokenImpl();
+    if (token) {
+      this.stream = this.stream.slice(token.length);
+      return token;
+    }
+  }
+
+  /**
+   *
+   * @returns {?Token}
+   */
+  _peekTokenImpl() {
     for (let type in detect) {
       if (detect.hasOwnProperty(type)) {
         if (detect[type].test(this.stream)) {
           const token = streamReaders[type](this.stream);
           if (token) {
             token.text = this.stream.substr(0, token.length);
-            this.stream = this.stream.slice(token.length);
             return token;
           }
         }
       }
     }
+  }
+
+  peekToken() {
+    return this._fixedReadToken ? this._fixedReadToken() : this._peekTokenImpl();
   }
 
   /**

--- a/test/helpers/testPeek.js
+++ b/test/helpers/testPeek.js
@@ -1,0 +1,13 @@
+import HtmlParser from '../../src/HtmlParser';
+
+export function peeks(s, options = {}, theTest) {
+  if (typeof options == 'function') {
+    theTest = options;
+    options = {};
+  }
+
+  const parser = typeof s === 'string' ? new HtmlParser(s, options) : s;
+  const tok = parser.peekToken();
+
+  return () => theTest(tok, parser);
+}

--- a/test/unit/attributes.spec.js
+++ b/test/unit/attributes.spec.js
@@ -1,4 +1,5 @@
 import {parses} from '../helpers/testParse';
+import {peeks} from '../helpers/testPeek';
 
 describe('HtmlParser', () => {
   describe('#readToken', () => {
@@ -112,4 +113,17 @@ describe('HtmlParser', () => {
     }));
   });
 
+  describe('#peek', () => {
+    const TAG = '<img/>';
+
+    it('does not mutate the stream', peeks(TAG, (token, parser) => {
+      expect(parser.rest()).to.equal(token.toString());
+    }));
+    it('shows the next token', peeks(TAG, (token) => {
+      expect(token.toString()).to.equal(TAG);
+    }));
+    it('returns undefined when there are no more tokens', peeks('', (token) => {
+      expect(token).to.be(undefined);
+    }));
+  });
 });


### PR DESCRIPTION
Can now see what token is coming w/o consuming it.