### PR TITLE
chore(coverage): publish coverage to codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,11 @@ engines:
       - javascript
   eslint:
     enabled: true
+    checks:
+      strict:
+        enabled: false
+      keyword-spacing:
+        enabled: false
   fixme:
     enabled: true
 ratings:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,12 @@ script:
   fi
 
 after_success:
-  - npm run semantic-release
+- |
+  npm run semantic-release
+  if [ "${TRAVIS_PULL_REQUEST}" != "true" ]; then
+    npm install codeclimate-test-reporter
+    ./node_modules/.bin/codeclimate-test-reporter < build/test-reports/coverage/*/lcov.info
+  fi
 
 branches:
   except:

--- a/test/karma-ci.config.babel.js
+++ b/test/karma-ci.config.babel.js
@@ -30,12 +30,12 @@ module.exports = config => {
       }
     },
 
-    dir: '../dist/test-reports/coverage/',
+    dir: '../build/test-reports/coverage/',
 
     reporters: [
       {type: 'text-summary'},
       {type: 'text'},
-      {type: 'lcov', dir: '../dist/test-reports/coverage/'}
+      {type: 'lcov', dir: '../build/test-reports/coverage/'}
     ]
   };
 

--- a/test/karma-coverage.config.babel.js
+++ b/test/karma-coverage.config.babel.js
@@ -30,8 +30,6 @@ module.exports = config => {
       }
     },
 
-    dir: 'dist/test-reports/coverage/',
-
     reporters: [
       {type: 'text-summary'},
       {type: 'text'}


### PR DESCRIPTION
Previously, we were only publishing coverage to coveralls and using code climate for analysis