### PR TITLE
chore(build): add a karma config for intellij

### DIFF
--- a/test/karma-intellij.config.js
+++ b/test/karma-intellij.config.js
@@ -1,0 +1,6 @@
+require('babel-register');
+require('process');
+
+process.chdir('..');
+
+module.exports = require('./karma-nocoverage.config.babel');


### PR DESCRIPTION
This allows running tests in IntelliJ. Unfortunately, we'd need to completely reconfigure to get
coverage b/c coverage needs to be handled by the IntelliJ reporter to get the nice reports and it's
currently run by webpack..