### PR TITLE
fix(HtmlParser): return null for unclosed script and style tags

### DIFF
--- a/src/HtmlParser.js
+++ b/src/HtmlParser.js
@@ -99,7 +99,7 @@ export default class HtmlParser {
           const token = streamReaders[type](this.stream);
 
           if (token) {
-            if (token.type == 'startTag' &&
+            if (token.type === 'startTag' &&
                 (/script|style/i).test(token.tagName)) {
               return null;
             } else {

--- a/src/HtmlParser.js
+++ b/src/HtmlParser.js
@@ -51,7 +51,7 @@ export default class HtmlParser {
       this._peekToken = fixedReadTokenFactory(this, fixedTokenOptions, () => this._peekTokenImpl());
     } else {
       this._readToken = this._readTokenImpl;
-      this._peekToken = this._peekTokenImpl
+      this._peekToken = this._peekTokenImpl;
     }
   }
 

--- a/test/karma-intellij.config.js
+++ b/test/karma-intellij.config.js
@@ -1,5 +1,5 @@
 require('babel-register');
-require('process');
+var process = require('process');
 
 process.chdir('..');
 

--- a/test/unit/tags.spec.js
+++ b/test/unit/tags.spec.js
@@ -2,6 +2,38 @@ import {testParse, parses, fixes, parsesCompletely} from '../helpers/testParse';
 
 describe('HtmlParser (tags)', () => {
   describe('#readToken', () => {
+    it('parses closed div tag completely', parsesCompletely('<div id="foo">hi there</div>', s => {
+      expect(s).to.equal('<div id="foo">hi there</div>');
+    }));
+
+    it('parses closed script tag completely', parsesCompletely('<script id="foo" type="text/javascript">// hi there</script>', s => {
+      expect(s).to.equal('<script id="foo" type="text/javascript">// hi there</script>');
+    }));
+
+    it('parses closed style tag completely', parsesCompletely('<style id="foo" type="text/css">/* hi there */</style>', s => {
+      expect(s).to.equal('<style id="foo" type="text/css">/* hi there */</style>');
+    }));
+
+    it('parses open div tag completely', parsesCompletely('<div id="foo">hi there', s => {
+      expect(s).to.equal('<div id="foo">hi there');
+    }));
+
+    it('parses open script tag completely', parsesCompletely('<script id="foo" text="text/javascript">// hi there', s => {
+      expect(s).to.equal('');
+    }));
+
+    it('parses open style tag completely', parsesCompletely('<style id="foo" text="text/css">/* hi there */', s => {
+      expect(s).to.equal('');
+    }));
+
+    it('parses open SCRIPT tag completely', parsesCompletely('<SCRIPT id="foo" text="text/javascript">// hi there', s => {
+      expect(s).to.equal('');
+    }));
+
+    it('parses open STYLE tag completely', parsesCompletely('<STYLE id="foo" text="text/css">/* hi there */', s => {
+      expect(s).to.equal('');
+    }));
+
     it('parses lower case tags', parses('<img src="http://localhost/">', (tok, str) => {
       expect(tok).to.have.property('tagName', 'img');
       expect(tok).to.have.property('type', 'startTag');


### PR DESCRIPTION
In the original version of HtmlParser embedded in postscribe, we would return null for script and
style tokens.  This behaviour appears to have changed in the extraction and we should revert to that
earlier behaviour since it makes no sense to return just the start tag for script and style.

Fixes #35