### PR TITLE
Comments function has been refactored to use substring instead of substr

### DIFF
--- a/src/streamReaders.js
+++ b/src/streamReaders.js
@@ -20,9 +20,12 @@ const REGEXES = {
  * @returns {CommentToken}
  */
 export function comment(stream) {
-  const index = stream.indexOf('-->');
+  const endNeedle = '-->';
+  const index = stream.indexOf(endNeedle);
+  const startIndex = String('<!--').length;
+  const endIndex = index + endNeedle.length;
   if (index >= 0) {
-    return new CommentToken(stream.substr(4, index - 1), index + 3);
+    return new CommentToken(stream.substring(startIndex, endIndex), endIndex);
   }
 }
 


### PR DESCRIPTION
Some customers have the following creatives:
```
function markup() {/*
    <_test!doctype html>
    <_testhtml>
      <_testhead></_testhead>
      <_testbody style="margin:0px">
        <_testh1> This is a Test </_testh1>
        <_testdiv class="test_creative" style="width:320px;height:50px;">
            <_testscript type='text/javascript'>
                console.log('TEST')
            </_testscript>
        </_testdiv>
        </_testbody>
    </_testhtml>
*/}
function parsingFn(func) {
    return func.toString().replace(/(<|\*)(\/)?_test/g,"$1$2").split(/\n/).slice(1, -1).join('\n');
}
document.write(parsingFn(markup));
document.close();
```

Which is not working with the current version of Postscribe. The PR fixes the problem